### PR TITLE
Fix returned value in Singleton::GetPlayerInfo method

### DIFF
--- a/matchmakingservice.lua
+++ b/matchmakingservice.lua
@@ -613,7 +613,7 @@ end
 --- Gets the player info.
 -- @param player The player to get.
 function MatchmakingService:GetPlayerInfo(player)
-  self:GetPlayerInfoId(player.UserId)
+  return self:GetPlayerInfoId(player.UserId)
 end
 
 --- Counts how many players are in the queues.


### PR DESCRIPTION
Hi, so I'm working on porting for roblox-ts (TypeScript transpiler to Lua).

However, I saw a method (GetPlayerInfo) not being returned. So I fixed it up and good to go.
